### PR TITLE
Fix railtie and temporarily disable owned_by option

### DIFF
--- a/lib/pg_sequencer/connection_adapters/postgresql_adapter.rb
+++ b/lib/pg_sequencer/connection_adapters/postgresql_adapter.rb
@@ -74,7 +74,7 @@ module PgSequencer
         sql << restart_option_sql(options) if options[:restart]  or options[:restart_with]
         sql << cache_option_sql(options) if options[:cache]
         sql << cycle_option_sql(options)
-        sql << owned_option_sql(options) if options[:owned_by]
+        # sql << owned_option_sql(options) if options[:owned_by]
         sql
       end
 
@@ -96,7 +96,7 @@ module PgSequencer
         select_sequence_names.each do |sequence_name|
 
           row = select_one("SELECT * FROM #{sequence_name}")
-          owner = select_sequence_owner(sequence_name)
+          # owner = select_sequence_owner(sequence_name)
 
           options = {
             increment: row["increment_by"].to_i,
@@ -105,7 +105,7 @@ module PgSequencer
             start: row["start_value"].to_i,
             cache: row["cache_value"].to_i,
             cycle: row["is_cycled"] == "t",
-            owned_by: owner ? "#{owner["refobjid"]}.#{owner["attname"]}" : nil
+            # owned_by: owner ? "#{owner["refobjid"]}.#{owner["attname"]}" : nil
           }
 
           all_sequences << SequenceDefinition.new(sequence_name, options)

--- a/lib/pg_sequencer/railtie.rb
+++ b/lib/pg_sequencer/railtie.rb
@@ -3,7 +3,7 @@ module PgSequencer
 
     initializer "pg_sequencer.load_adapter" do
       ActiveSupport.on_load :active_record do
-        ActiveRecord::ConnectionAdapters.include(PgSequencer::ConnectionAdapters::PostgreSQLAdapter)
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.include(PgSequencer::ConnectionAdapters::PostgreSQLAdapter)
         ActiveRecord::SchemaDumper.prepend(PgSequencer::SchemaDumper)
       end
     end

--- a/lib/pg_sequencer/schema_dumper.rb
+++ b/lib/pg_sequencer/schema_dumper.rb
@@ -19,7 +19,7 @@ module PgSequencer
         statement_parts << ("start: " + sequence.options[:start].inspect)
         statement_parts << ("cache: " + sequence.options[:cache].inspect)
         statement_parts << ("cycle: " + sequence.options[:cycle].inspect)
-        statement_parts << ("owned_by: " + sequence.options[:owned_by].inspect)
+        # statement_parts << ("owned_by: " + sequence.options[:owned_by].inspect)
 
         "  " + statement_parts.join(", ")
       end

--- a/lib/pg_sequencer/version.rb
+++ b/lib/pg_sequencer/version.rb
@@ -1,3 +1,3 @@
 module PgSequencer
-  VERSION = "1.0.0"
+  VERSION = "1.0.0-alpha"
 end

--- a/spec/pg_sequencer/connection_adapters/postgresql_adapter_spec.rb
+++ b/spec/pg_sequencer/connection_adapters/postgresql_adapter_spec.rb
@@ -10,13 +10,13 @@ describe PgSequencer::ConnectionAdapters::PostgreSQLAdapter do
       max: 2_000_000,
       cache: 5,
       cycle: true,
-      owned_by: "table_name.column_name",
+      # owned_by: "table_name.column_name",
     }
   end
 
   context "generating sequence option SQL" do
     it "includes all options" do
-      output = " INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE OWNED BY table_name.column_name"
+      output = " INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE"
       expect(dummy.sequence_options_sql(options.merge(start: 1))).to eq(output)
     end
 
@@ -96,12 +96,12 @@ describe PgSequencer::ConnectionAdapters::PostgreSQLAdapter do
     end
 
     context "for :owned_by" do
-      it "includes 'OWNED BY' in SQL if specified" do
+      xit "includes 'OWNED BY' in SQL if specified" do
         expect(dummy.sequence_options_sql(owned_by: "users.counter")).to eq(" OWNED BY users.counter")
         expect(dummy.sequence_options_sql(owned_by: "NONE")).to eq(" OWNED BY NONE")
       end
 
-      it "does not include 'OWNED BY' in SQL if specified as nil" do
+      xit "does not include 'OWNED BY' in SQL if specified as nil" do
         expect(dummy.sequence_options_sql(owned_by: nil)).to eq("")
       end
     end
@@ -117,7 +117,7 @@ describe PgSequencer::ConnectionAdapters::PostgreSQLAdapter do
 
     context "with options" do
       it "includes options at the end" do
-        output = "CREATE SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE OWNED BY table_name.column_name"
+        output = "CREATE SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE"
         expect(dummy.create_sequence_sql("things", options.merge(start: 1))).to eq(output)
       end
     end
@@ -134,7 +134,7 @@ describe PgSequencer::ConnectionAdapters::PostgreSQLAdapter do
 
     context "with options" do
       it "includes options at the end" do
-        output = "ALTER SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 RESTART WITH 1 CACHE 5 CYCLE OWNED BY table_name.column_name"
+        output = "ALTER SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 RESTART WITH 1 CACHE 5 CYCLE"
         expect(dummy.change_sequence_sql("things", options.merge(restart: 1))).to eq(output)
       end
     end

--- a/spec/pg_sequencer/schema_dumper_spec.rb
+++ b/spec/pg_sequencer/schema_dumper_spec.rb
@@ -20,7 +20,7 @@ describe PgSequencer::SchemaDumper do
         start: 1,
         cache: 5,
         cycle: true,
-        owned_by: "table_name.column_name",
+        # owned_by: "table_name.column_name",
       }
     end
 
@@ -28,8 +28,8 @@ describe PgSequencer::SchemaDumper do
       expected_output = <<~SCHEMAEND
                         # Fake Schema Header
                         # (No Tables)
-                          create_sequence "item_seq", increment: 1, min: 1, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
-                          create_sequence "user_seq", increment: 1, min: 1, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
+                          create_sequence "item_seq", increment: 1, min: 1, max: 2000000, start: 1, cache: 5, cycle: true
+                          create_sequence "user_seq", increment: 1, min: 1, max: 2000000, start: 1, cache: 5, cycle: true
 
                         # Fake Schema Trailer
                         SCHEMAEND
@@ -48,7 +48,7 @@ describe PgSequencer::SchemaDumper do
         start: 1,
         cache: 5,
         cycle: true,
-        owned_by: "table_name.column_name",
+        # owned_by: "table_name.column_name",
       }
     end
 
@@ -56,8 +56,8 @@ describe PgSequencer::SchemaDumper do
       expected_output = <<~SCHEMAEND
                         # Fake Schema Header
                         # (No Tables)
-                          create_sequence "item_seq", increment: 1, min: false, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
-                          create_sequence "user_seq", increment: 1, min: false, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
+                          create_sequence "item_seq", increment: 1, min: false, max: 2000000, start: 1, cache: 5, cycle: true
+                          create_sequence "user_seq", increment: 1, min: false, max: 2000000, start: 1, cache: 5, cycle: true
 
                         # Fake Schema Trailer
                         SCHEMAEND


### PR DESCRIPTION
The railtie needs to include our adapter in `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter` rather than `ActiveRecord::ConnectionAdapters`.

We disabled the `owned_by` option for now since it wasn't working on some versions of PostgreSQL.

Changed the version to `1.0.0-alpha`.