### PR TITLE
Support ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ cache: bundler
 rvm:
   - 2.4.1
   - 2.3.4
+  - 2.2.7
+  - 2.1.10
+  - 2.0.0
 
 script: "bundle exec rake"

--- a/lib/pg_sequencer/connection_adapters/postgresql_adapter.rb
+++ b/lib/pg_sequencer/connection_adapters/postgresql_adapter.rb
@@ -120,7 +120,7 @@ module PgSequencer
       # --------------+--------------------
       # relname       | some_seq
       def select_sequence_names
-        sql = <<~SQL
+        sql = <<-SQL.strip_heredoc
               SELECT c.relname FROM pg_class c
               WHERE c.relkind = 'S' ORDER BY c.relname ASC
               SQL
@@ -133,7 +133,7 @@ module PgSequencer
       # refobjid      | some_table
       # attname       | some_column
       def select_sequence_owner(sequence_name)
-        sql = <<~SQL
+        sql = <<-SQL.strip_heredoc
               SELECT d.refobjid::regclass, a.attname
               FROM pg_depend d
               JOIN pg_attribute a ON a.attrelid = d.refobjid

--- a/lib/pg_sequencer/version.rb
+++ b/lib/pg_sequencer/version.rb
@@ -1,3 +1,3 @@
 module PgSequencer
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/pg_sequencer/schema_dumper_spec.rb
+++ b/spec/pg_sequencer/schema_dumper_spec.rb
@@ -25,7 +25,7 @@ describe PgSequencer::SchemaDumper do
     end
 
     it "outputs all sequences correctly" do
-      expected_output = <<~SCHEMAEND
+      expected_output = <<-SCHEMAEND.strip_heredoc
                         # Fake Schema Header
                         # (No Tables)
                           create_sequence "item_seq", increment: 1, min: 1, max: 2000000, start: 1, cache: 5, cycle: true
@@ -53,7 +53,7 @@ describe PgSequencer::SchemaDumper do
     end
 
     it "outputs false for schema output" do
-      expected_output = <<~SCHEMAEND
+      expected_output = <<-SCHEMAEND.strip_heredoc
                         # Fake Schema Header
                         # (No Tables)
                           create_sequence "item_seq", increment: 1, min: false, max: 2000000, start: 1, cache: 5, cycle: true


### PR DESCRIPTION
Add support for 2.0+ by removing features introduced in ruby 2.3. Added additional travis rvm versions for running tests on ruby 2.0, 2.1, and 2.2. Bumped version to `1.0.1`.