### PR TITLE
Support owned_by option and skip dumping primary keys

### DIFF
--- a/lib/pg_sequencer/schema_dumper.rb
+++ b/lib/pg_sequencer/schema_dumper.rb
@@ -11,7 +11,13 @@ module PgSequencer
     protected
 
     def sequences(stream)
-      sequence_statements = @connection.sequences.map do |sequence|
+      # Filter out sequences that are owned by table primary keys since rails
+      # already creates those for us.
+      unmanaged_sequences = @connection.sequences.select do |sequence|
+        !sequence.options[:owner_is_primary_key]
+      end
+
+      sequence_statements = unmanaged_sequences.map do |sequence|
         statement_parts = [ ("create_sequence ") + sequence.name.inspect ]
         statement_parts << ("increment: " + sequence.options[:increment].inspect)
         statement_parts << ("min: " + sequence.options[:min].inspect)
@@ -19,7 +25,7 @@ module PgSequencer
         statement_parts << ("start: " + sequence.options[:start].inspect)
         statement_parts << ("cache: " + sequence.options[:cache].inspect)
         statement_parts << ("cycle: " + sequence.options[:cycle].inspect)
-        # statement_parts << ("owned_by: " + sequence.options[:owned_by].inspect)
+        statement_parts << ("owned_by: " + sequence.options[:owned_by].inspect)
 
         "  " + statement_parts.join(", ")
       end

--- a/lib/pg_sequencer/version.rb
+++ b/lib/pg_sequencer/version.rb
@@ -1,3 +1,3 @@
 module PgSequencer
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/pg_sequencer/connection_adapters/postgresql_adapter_spec.rb
+++ b/spec/pg_sequencer/connection_adapters/postgresql_adapter_spec.rb
@@ -10,13 +10,13 @@ describe PgSequencer::ConnectionAdapters::PostgreSQLAdapter do
       max: 2_000_000,
       cache: 5,
       cycle: true,
-      # owned_by: "table_name.column_name",
+      owned_by: "table_name.column_name",
     }
   end
 
   context "generating sequence option SQL" do
     it "includes all options" do
-      output = " INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE"
+      output = " INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE OWNED BY table_name.column_name"
       expect(dummy.sequence_options_sql(options.merge(start: 1))).to eq(output)
     end
 
@@ -96,12 +96,16 @@ describe PgSequencer::ConnectionAdapters::PostgreSQLAdapter do
     end
 
     context "for :owned_by" do
-      xit "includes 'OWNED BY' in SQL if specified" do
+      it "includes 'OWNED BY table_name.column_name' in SQL if specified" do
         expect(dummy.sequence_options_sql(owned_by: "users.counter")).to eq(" OWNED BY users.counter")
-        expect(dummy.sequence_options_sql(owned_by: "NONE")).to eq(" OWNED BY NONE")
+        expect(dummy.sequence_options_sql(owned_by: "orders.number")).to eq(" OWNED BY orders.number")
       end
 
-      xit "does not include 'OWNED BY' in SQL if specified as nil" do
+      it "does not include 'OWNED BY' in SQL if specified as false" do
+        expect(dummy.sequence_options_sql(owned_by: false)).to eq("")
+      end
+
+      it "does not include 'OWNED BY' in SQL if specified as nil" do
         expect(dummy.sequence_options_sql(owned_by: nil)).to eq("")
       end
     end
@@ -117,7 +121,7 @@ describe PgSequencer::ConnectionAdapters::PostgreSQLAdapter do
 
     context "with options" do
       it "includes options at the end" do
-        output = "CREATE SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE"
+        output = "CREATE SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE OWNED BY table_name.column_name"
         expect(dummy.create_sequence_sql("things", options.merge(start: 1))).to eq(output)
       end
     end
@@ -134,7 +138,7 @@ describe PgSequencer::ConnectionAdapters::PostgreSQLAdapter do
 
     context "with options" do
       it "includes options at the end" do
-        output = "ALTER SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 RESTART WITH 1 CACHE 5 CYCLE"
+        output = "ALTER SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 RESTART WITH 1 CACHE 5 CYCLE OWNED BY table_name.column_name"
         expect(dummy.change_sequence_sql("things", options.merge(restart: 1))).to eq(output)
       end
     end

--- a/spec/pg_sequencer/schema_dumper_spec.rb
+++ b/spec/pg_sequencer/schema_dumper_spec.rb
@@ -20,19 +20,19 @@ describe PgSequencer::SchemaDumper do
         start: 1,
         cache: 5,
         cycle: true,
-        # owned_by: "table_name.column_name",
+        owned_by: "table_name.column_name",
       }
     end
 
     it "outputs all sequences correctly" do
-      expected_output = <<-SCHEMAEND.strip_heredoc
+      expected_output = <<-SCHEMA.strip_heredoc
                         # Fake Schema Header
                         # (No Tables)
-                          create_sequence "item_seq", increment: 1, min: 1, max: 2000000, start: 1, cache: 5, cycle: true
-                          create_sequence "user_seq", increment: 1, min: 1, max: 2000000, start: 1, cache: 5, cycle: true
+                          create_sequence "item_seq", increment: 1, min: 1, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
+                          create_sequence "user_seq", increment: 1, min: 1, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
 
                         # Fake Schema Trailer
-                        SCHEMAEND
+                        SCHEMA
 
       MockSchemaDumper.dump(connection, stream)
       expect(expected_output.strip).to eq(stream.to_s)
@@ -48,19 +48,19 @@ describe PgSequencer::SchemaDumper do
         start: 1,
         cache: 5,
         cycle: true,
-        # owned_by: "table_name.column_name",
+        owned_by: "table_name.column_name",
       }
     end
 
     it "outputs false for schema output" do
-      expected_output = <<-SCHEMAEND.strip_heredoc
+      expected_output = <<-SCHEMA.strip_heredoc
                         # Fake Schema Header
                         # (No Tables)
-                          create_sequence "item_seq", increment: 1, min: false, max: 2000000, start: 1, cache: 5, cycle: true
-                          create_sequence "user_seq", increment: 1, min: false, max: 2000000, start: 1, cache: 5, cycle: true
+                          create_sequence "item_seq", increment: 1, min: false, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
+                          create_sequence "user_seq", increment: 1, min: false, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
 
                         # Fake Schema Trailer
-                        SCHEMAEND
+                        SCHEMA
 
       MockSchemaDumper.dump(connection, stream)
       expect(expected_output.strip).to eq(stream.to_s)


### PR DESCRIPTION
Support `owned_by` option for both `create_sequence` and `change_sequence`.   

Ignore dumping to `schema.rb` for sequences that are owned by primary keys. ActiveRecord is already managing those sequences.  Dump sequences owned by primary keys result in a PostgreSQL duplication error.  

Bump version to `1.0.2`.