### PR TITLE
Move dumped create sequences above create tables

### DIFF
--- a/lib/pg_sequencer/schema_dumper.rb
+++ b/lib/pg_sequencer/schema_dumper.rb
@@ -4,8 +4,8 @@ module PgSequencer
   module SchemaDumper
 
     def tables(stream)
-      super(stream)
       sequences(stream)
+      super(stream)
     end
 
     protected

--- a/lib/pg_sequencer/version.rb
+++ b/lib/pg_sequencer/version.rb
@@ -1,3 +1,3 @@
 module PgSequencer
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/spec/pg_sequencer/schema_dumper_spec.rb
+++ b/spec/pg_sequencer/schema_dumper_spec.rb
@@ -27,10 +27,10 @@ describe PgSequencer::SchemaDumper do
     it "outputs all sequences correctly" do
       expected_output = <<-SCHEMA.strip_heredoc
                         # Fake Schema Header
-                        # (No Tables)
                           create_sequence "item_seq", increment: 1, min: 1, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
                           create_sequence "user_seq", increment: 1, min: 1, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
 
+                        # (No Tables)
                         # Fake Schema Trailer
                         SCHEMA
 
@@ -55,10 +55,10 @@ describe PgSequencer::SchemaDumper do
     it "outputs false for schema output" do
       expected_output = <<-SCHEMA.strip_heredoc
                         # Fake Schema Header
-                        # (No Tables)
                           create_sequence "item_seq", increment: 1, min: false, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
                           create_sequence "user_seq", increment: 1, min: false, max: 2000000, start: 1, cache: 5, cycle: true, owned_by: "table_name.column_name"
 
+                        # (No Tables)
                         # Fake Schema Trailer
                         SCHEMA
 


### PR DESCRIPTION
The `create_sequence`s in `schema.rb` need to be located above all create tables since some table column defaults will directly reference the already existing sequence tables.  For example, `default: -> { "nextval('order_number_seq'::regclass)" }` And PostgreSQL complains if the sequences do not already exist.

Unfortunately this means that the new `owned_by` option won't be all that useful until we dump `create_sequence` at the top of the schema (sans `owned_by`) and dump `change_sequence "my_seq", owned_by: "table_name.column_name"` at the bottom of the schema.